### PR TITLE
Add Post Configuration Actions step to DB and SAP installation pipeline

### DIFF
--- a/pipelines/05-DB-and-SAP-installation.yml
+++ b/pipelines/05-DB-and-SAP-installation.yml
@@ -112,6 +112,11 @@ parameters:
     type:                              boolean
     default:                           false
 
+  - name:                              post_configuration_actions
+    displayName:                       Post Configuration Actions
+    type:                              boolean
+    default:                           false
+
 # 20220929 MKD - ACSS Registration <BEGIN>
   - name:                              acss_registration
     displayName:                       Register System in ACSS
@@ -164,6 +169,7 @@ extends:
           pas_installation:                ${{ parameters.pas_installation }}
           application_server_installation: ${{ parameters.application_server_installation }}
           webdispatcher_installation:      ${{ parameters.webdispatcher_installation }}
+          post_configuration_actions:      ${{ parameters.post_configuration_actions }}
           acss_registration:               ${{ parameters.acss_registration }}
           acss_environment:                ${{ parameters.acss_environment }}
           acss_sap_product:                ${{ parameters.acss_sap_product }}


### PR DESCRIPTION
This PR introduces a new Post Configuration Actions step in the 05-DB-and-SAP-installation pipeline.
This will faciliate SDAF users to create `_pre` and `_post` ansible hooks in their Config Repoistory, after a system has been fully configured and installed by SDAF.

This has a dependency with a [PR](https://github.com/Azure/sap-automation/pull/545) in the `sap-automation` repository.