### PR TITLE
Add sap on azure quality check step to the 05-DB-and-SAP-installation pipeline

### DIFF
--- a/pipelines/05-DB-and-SAP-installation.yml
+++ b/pipelines/05-DB-and-SAP-installation.yml
@@ -117,6 +117,11 @@ parameters:
     type:                              boolean
     default:                           false
 
+  - name:                              sap_on_azure_quality_checks
+    displayName:                       SAP on Azure Quality Checks
+    type:                              boolean
+    default:                           false
+
   - name:                              post_configuration_actions
     displayName:                       Post Configuration Actions
     type:                              boolean
@@ -181,6 +186,7 @@ extends:
           pas_installation:                ${{ parameters.pas_installation }}
           application_server_installation: ${{ parameters.application_server_installation }}
           webdispatcher_installation:      ${{ parameters.webdispatcher_installation }}
+          sap_on_azure_quality_checks:     ${{ parameters.sap_on_azure_quality_checks }}
           post_configuration_actions:      ${{ parameters.post_configuration_actions }}
           acss_registration:               ${{ parameters.acss_registration }}
           acss_environment:                ${{ parameters.acss_environment }}


### PR DESCRIPTION
This adds the sap_on_azure_quality_checks parameter to the bootstrapping of SDAF.
This facilitates that new SDAF repos can use the functionality provided by this step.

*BE AWARE* this PR is closely linked with a [PR](https://github.com/Azure/sap-automation/pull/595) in the Azure/sap-automation repo.