### PR TITLE
Update PostBuildCleanup to the latest version

### DIFF
--- a/pipelines/22-sample-deployer-configuration.yml
+++ b/pipelines/22-sample-deployer-configuration.yml
@@ -141,7 +141,7 @@ stages:
         workspace:
           clean:                       all
         steps:
-          - task:                      PostBuildCleanup@3
+          - task:                      PostBuildCleanup@4
           - checkout:                  self
             persistCredentials:        true
           - task:                      PowerShell@2


### PR DESCRIPTION
## Problem
Some of our customers are encountering an error stating that the old version of the PostBuildCleanup task cannot be found.

![image](https://github.com/user-attachments/assets/70b289b7-3532-4ae5-96da-2e939f8d183d)

## Solution
Update the `PostBuildCleanup` task to the latest version in the `pipelines/22-sample-deployer-configuration.yml` file to resolve the issue.

