### PR TITLE
Fix MSI_ID handling and Region Mapping syntax in deployer configuration

### DIFF
--- a/pipelines/22-sample-deployer-configuration.yml
+++ b/pipelines/22-sample-deployer-configuration.yml
@@ -44,7 +44,7 @@ parameters:
       - NOEU
       - NOEA
       - NOWE
-      - NzNO
+      - NZNO
       - PLCE
       - QACE
       - SANO
@@ -67,7 +67,6 @@ parameters:
       - WEUS
       - WUS2
       - WUS3
-      - NZNO
   - name:                              workload_environment_parameter
     displayName:                       First Workload Environment name (MGMT, DEV, QA, PRD, ...)
     type:                              string
@@ -243,8 +242,7 @@ stages:
                      "wein" { "westindia"  }
                      "weus" { "westus" }
                      "wus2" { "westus2" }
-                     "wus3" { "westus3" }
-                     "nzno" { "newzealandnorth" }                    }
+                     "wus3" { "westus3" }                    }
 
                     $msi_id_val = '$(MSI_ID)'
                     $msi_id = if ($msi_id_val -match 'Microsoft\.ManagedIdentity') { 

--- a/pipelines/22-sample-deployer-configuration.yml
+++ b/pipelines/22-sample-deployer-configuration.yml
@@ -179,7 +179,6 @@ stages:
             displayName:               "Create Sample"
             inputs:
               targetType:              "inline"
-
               script: |
                     git fetch -q --all
                     git checkout -q $(Build.SourceBranchName)
@@ -189,73 +188,72 @@ stages:
 
                     $FolderName = "WORKSPACES"
                     $region = switch ("$(deployer_region)") {
-                     "auce" = { australiacentral" } 
-                     "auc2" = { "australiacentral2" }
-                     "auea" = { "australiaeast" }
-                     "ause" = { "australiasoutheast" }
-                     "brso" = { "brazilsouth" }
-                     "brse" = { "brazilsoutheast" }
-                     "brus" = { "brazilus" }
-                     "cace" = { "canadacentral" }
-                     "caea" = { "canadaeast" }
-                     "cein" = { "centralindia"       }
-                     "ceus" = { "centralus"  }
-                     "ceua" = { "centraluseuap" }
-                     "eaas" = { "eastasia" }
-                     "eaus" = { "eastus" }
-                     "eus2" = { "eastus2" }
-                     "eusa" = { "eastus2euap" }
-                     "eusg" = { "eastusstg"  }
-                     "frce" = { "francecentral" }
-                     "frso" = { "francesouth" }
-                     "geno" = { "germanynorth" }
-                     "gewc" = { "germanywestcentral" }
-                     "isce" = { "israelcentral" }
-                     "itno" = { "italynorth" }
-                     "jaea" = { "japaneast" }
-                     "jawe" = { "japanwest" }
-                     "jinc" = { "jioindiacentral" }
-                     "jinw" = { "jioindiawest" }
-                     "koce" = { "koreacentral" }
-                     "koso" = { "koreasouth" }
-                     "ncus" = { "northcentralus" }
-                     "noeu" = { "northeurope" }
-                     "noea" = { "norwayeast" }
-                     "nowe" = { "norwaywest" }
-                     "nzno" = { "newzealandnorth" } 
-                     "plce" = { "polandcentral" }
-                     "qace" = { "qatarcentral"       }
-                     "sano" = { "southafricanorth" }
-                     "sawe" = { "southafricawest" }
-                     "scus" = { "southcentralus" }
-                     "scug" = { "southcentralusstg"  }
-                     "soea" = { "southeastasia" }
-                     "soin" = { "southindia" }
-                     "sece" = { "swedencentral" }
-                     "seso" = { "swedensouth" }
-                     "swno" = { "switzerlandnorth" }
-                     "swwe" = { "switzerlandwest" }
-                     "uace" = { "uaecentral" }
-                     "uano" = { "uaenorth" }
-                     "ukso" = { "uksouth" }
-                     "ukwe" = { "ukwest" }
-                     "wcus" = { "westcentralus" }
-                     "weeu" = { "westeurope" }
-                     "wein" = { "westindia"  }
-                     "weus" = { "westus" }
-                     "wus2" = { "westus2" 
-                     "wus3" = { "westus3" }
-                     "nzno" = { "newzealandnorth" }                    }
+                     "auce" { "australiacentral" } 
+                     "auc2" { "australiacentral2" }
+                     "auea" { "australiaeast" }
+                     "ause" { "australiasoutheast" }
+                     "brso" { "brazilsouth" }
+                     "brse" { "brazilsoutheast" }
+                     "brus" { "brazilus" }
+                     "cace" { "canadacentral" }
+                     "caea" { "canadaeast" }
+                     "cein" { "centralindia" }
+                     "ceus" { "centralus"  }
+                     "ceua" { "centraluseuap" }
+                     "eaas" { "eastasia" }
+                     "eaus" { "eastus" }
+                     "eus2" { "eastus2" }
+                     "eusa" { "eastus2euap" }
+                     "eusg" { "eastusstg"  }
+                     "frce" { "francecentral" }
+                     "frso" { "francesouth" }
+                     "geno" { "germanynorth" }
+                     "gewc" { "germanywestcentral" }
+                     "isce" { "israelcentral" }
+                     "itno" { "italynorth" }
+                     "jaea" { "japaneast" }
+                     "jawe" { "japanwest" }
+                     "jinc" { "jioindiacentral" }
+                     "jinw" { "jioindiawest" }
+                     "koce" { "koreacentral" }
+                     "koso" { "koreasouth" }
+                     "ncus" { "northcentralus" }
+                     "noeu" { "northeurope" }
+                     "noea" { "norwayeast" }
+                     "nowe" { "norwaywest" }
+                     "nzno" { "newzealandnorth" } 
+                     "plce" { "polandcentral" }
+                     "qace" { "qatarcentral"       }
+                     "sano" { "southafricanorth" }
+                     "sawe" { "southafricawest" }
+                     "scus" { "southcentralus" }
+                     "scug" { "southcentralusstg"  }
+                     "soea" { "southeastasia" }
+                     "soin" { "southindia" }
+                     "sece" { "swedencentral" }
+                     "seso" { "swedensouth" }
+                     "swno" { "switzerlandnorth" }
+                     "swwe" { "switzerlandwest" }
+                     "uace" { "uaecentral" }
+                     "uano" { "uaenorth" }
+                     "ukso" { "uksouth" }
+                     "ukwe" { "ukwest" }
+                     "wcus" { "westcentralus" }
+                     "weeu" { "westeurope" }
+                     "wein" { "westindia"  }
+                     "weus" { "westus" }
+                     "wus2" { "westus2" }
+                     "wus3" { "westus3" }
+                     "nzno" { "newzealandnorth" }                    }
 
-                    $msi_id="$(MSI_ID)"
-                    
-                    $msi_id=$msi_id.Trim()
-                    if ($msi_id.Contains('Microsoft.ManagedIdentity')) {
-                      Write-Host "Using Managed Identity ($msi_id)"
+                    $msi_id_val = '$(MSI_ID)'
+                    $msi_id = if ($msi_id_val -match 'Microsoft\.ManagedIdentity') { 
+                        Write-Host "Using Managed Identity ($msi_id_val)"
+                        $msi_id_val.Trim() 
                     }
-                    else {
-                      Write-Host "Not using Managed Identity ($msi_id)"
-                      $msi_id=""
+                    else { 
+                        Write-Host "Not using Managed Identity"
+                        "" 
                     }
 
                     $Full = Join-Path -Path $($FolderName) -ChildPath (Join-Path -Path "DEPLOYER" -ChildPath $(deployer_folder))


### PR DESCRIPTION
# Fix MSI_ID handling and Region Mapping syntax in deployer configuration

### Description
Updated the `Create_Deployer_Configuration` job in `pipelines/22-sample-deployer-configuration.yml` to fix `MSI_ID` variable handling and correct syntax errors in the region mapping logic.

### Changes
- **MSI_ID Handling:**
    - Removed the explicit environment variable mapping `MSI_ID: $(MSI_ID)`.
    - Modified the PowerShell script to safely check if `$(MSI_ID)` is defined and contains a valid Managed Identity ID.
    - Switched to using single quotes (`'$(MSI_ID)'`) for the variable check to prevent PowerShell syntax errors when the variable is undefined or empty.
- **Region Mapping Refactor:**
    - Corrected the syntax in the PowerShell `switch` statement for region mapping. Removed incorrect assignment operators (`=`) and ensured proper string quoting for all region keys and values (e.g., changed `"auce" = { australiacentral" }` to `"auce" { "australiacentral" }`).

### Reasoning
- **MSI_ID:** The previous implementation relied on mapping `$(MSI_ID)` to an environment variable, which could cause issues if the variable was not set. The new approach directly checks the value injected by the pipeline, ensuring the script works robustly for both Managed Identity and Service Principal (SPN)# Fix MSI_ID handling and Region Mapping syntax in deployer configuration
