### PR TITLE
docs: add Azure DevOps deployment journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,146 @@
-# Project
+# SAP Deployment Automation Framework for Azure DevOps
 
-This repository contains the core pipelines for calling the SDAF Azure DevOps pipelines.
+This repository is the customer configuration and wrapper-pipeline repository
+for running SAP Deployment Automation Framework (SDAF) through Azure DevOps.
+It stores deployment configuration under `WORKSPACES` and calls implementation
+templates from the separate `sap-automation` code repository.
 
-It will also contain the Terraform configuration files used for deploying the infrastructure required for the SAP Deployment Automation Framework deployments.
+For framework architecture, execution-model selection, and local execution,
+return to the central
+[`Azure/sap-automation`](https://github.com/Azure/sap-automation) documentation
+hub.
+
+Use the current Microsoft Learn article,
+[Configure Azure DevOps for SAP Deployment Automation](https://learn.microsoft.com/azure/sap/automation/configure-devops?tabs=linux),
+as the supported setup baseline. The pages in this repository organize that
+journey and add details verified against the current wrapper pipelines.
+
+## Start the Azure DevOps journey
+
+Complete the journey in order:
+
+1. [Prepare Azure and Azure DevOps prerequisites](docs/01-00-prerequisites.md).
+   You confirm access, identity, networking, quota, SAP access, and agent
+   readiness.
+2. [Bootstrap the Azure DevOps project](docs/02-00-bootstrap.md). You create or
+   configure repositories, variable groups, service connections, pipelines,
+   permissions, and agent pools.
+3. [Deploy the control plane](docs/03-00-control-plane.md). You prepare deployer
+   and library configuration, review the test run, and run pipeline `01`.
+4. [Deploy a workload zone](docs/04-00-workload-zone.md). You prepare landscape
+   configuration and run pipeline `02`.
+5. [Deploy SAP-system infrastructure](docs/05-00-sap-system.md). You prepare
+   system configuration and run pipeline `03`.
+6. [Acquire software and install SAP](docs/06-00-software-and-installation.md).
+   You select a bill of materials (BOM), download software, and run the selected
+   installation stages.
+7. [Operate or remove the deployment](docs/07-00-operations.md). You update
+   repositories and pipelines, rotate credentials, and perform controlled
+   removal.
+
+Use [Troubleshoot Azure DevOps deployments](docs/troubleshooting.md) for
+symptom-based diagnostics and [Pipeline reference](docs/pipeline-reference.md)
+for the wrapper-to-template map.
+
+For automated setup, run the documented scripts in this order:
+
+1. [Configure the Azure DevOps project and control-plane artifacts](docs/02-10-configure-devops-project.md).
+2. [Configure workload-zone artifacts](docs/02-20-configure-workload-zone-artifacts.md).
+
+These scripts configure Azure DevOps assets. They don't deploy Azure
+infrastructure. Run the deployment pipelines in the remaining journey steps.
+
+## Current capability boundaries
+
+Azure DevOps and GitHub Actions implement the same SDAF lifecycle, but their
+automation is not identical.
+
+- Pipeline `22-sample-deployer-configuration.yml` creates deployer and library
+  examples and rewrites selected wrapper defaults.
+- No verified full Azure DevOps equivalent exists for GitHub configuration
+  workflow `02`, which generates workload-zone configuration.
+- No verified full Azure DevOps equivalent exists for GitHub configuration
+  workflow `04`, which generates SAP-system configuration.
+- Prepare workload-zone and SAP-system files from reviewed
+  [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples)
+  content, the SDAF configuration Web application where applicable, or direct
+  customer editing. Store the reviewed files under `WORKSPACES`.
+- The public selection criteria for
+  `04-sap-software-download.yml` and
+  `04-sap-software-download_v2.yml` are not confirmed. Review their parameter
+  models and your release guidance before selecting one.
+- `07-sap-cal-installation.yml` references a core template that was not present
+  in the validated `sap-automation` checkout. Do not run it until the referenced
+  core repository ref contains and validates that template.
+- Pipeline `01` does not pass its `test` parameter to the deployment scripts.
+  Do not use that parameter as a plan-only gate.
+- Pipelines `02` and `03` pass `TEST_ONLY` through their v1 or v2 pipeline
+  scripts to `installer.sh` or `installer_v2.sh`. Use `test: true` to produce a
+  Terraform plan without applying it.
+
+## Repository layout
+
+| Path | Ownership |
+| --- | --- |
+| `WORKSPACES/DEPLOYER` | Customer deployer Terraform variable files |
+| `WORKSPACES/LIBRARY` | Customer SAP library Terraform variable files |
+| `WORKSPACES/LANDSCAPE` | Customer workload-zone Terraform variable files |
+| `WORKSPACES/SYSTEM` | Customer SAP-system Terraform variable files |
+| `pipelines/` | Azure DevOps wrappers and standalone maintenance pipelines |
+| `pipelines/resources.yml` | `sap-automation` repository resource |
+| `pipelines/resources_including_samples.yml` | `sap-automation` and `sap-samples` repository resources |
+| `Ansible/` | Customer-owned Ansible extensions |
+
+The resource files currently select `main`. For reproducible production
+deployments, review the referenced repositories and pin an approved ref through
+your controlled update process.
+
+## Pipeline sequence
+
+| Order | Pipeline | Outcome |
+| --- | --- | --- |
+| Optional | `22-sample-deployer-configuration.yml` | Creates control-plane examples and updates selected defaults |
+| 1 | `01-deploy-control-plane.yml` | Deploys the deployer, SAP library, and optional configuration Web application |
+| 2 | `02-sap-workload-zone.yml` | Stores deployment credentials and deploys a workload zone |
+| 3 | `03-sap-system-deployment.yml` | Deploys SAP-system infrastructure |
+| 4 | `04-sap-software-download.yml` or `_v2.yml` | Downloads SAP software from a selected BOM model |
+| 5 | `05-DB-and-SAP-installation.yml` | Runs selected OS, database, and SAP installation stages |
+| Optional | `07-sap-cal-installation.yml` | Azure DevOps CAL wrapper; validate its core template before use |
+| Operations | `20`, `21`, `10`, `11`, and `12` | Updates or removes deployment components |
+
+All wrappers have `trigger: none`. Queue them deliberately after reviewing
+their runtime parameters.
 
 ## How it works
 
-During pipeline execution the two repositories will be present on the deployer-agent. Each of the repositories will be mapped using the following:
+During template-driven execution, the core download templates map repositories
+on the agent as follows:
 
-- sap-automation will be mapped to ```/sap-automation```
-- customer configuration repository will be mapped to ```/config```
-
-During execution the repositories will interact with each other by using the following:
+- `sap-automation` maps to `$(Build.SourcesDirectory)/sap-automation`.
+- This customer configuration repository maps to
+  `$(Build.SourcesDirectory)/config`.
+- Software-download pipelines also map the sample repository to
+  `$(Build.SourcesDirectory)/samples`.
 
 ```mermaid
 flowchart LR
-    subgraph deployer-agent
-        pipeline--uses-->templated-pipelines
-        templated-pipelines--uses-->workspace-configuration
-        subgraph customer repository
-            workspace-configuration
-            pipeline
-        end
-        subgraph sap-automation
-        templated-pipelines--executes-->sap-installation
-        end
-    end
+    A[Azure DevOps wrapper pipeline] --> B[Core pipeline template]
+    C[Customer WORKSPACES configuration] --> B
+    D[sap-automation code repository] --> B
+    E[SAP automation samples] --> B
+    B --> F[Azure resources, remote Terraform state, or SAP configuration]
 ```
+
+The wrapper owns customer-selectable defaults and repository wiring. The core
+template in `Azure/sap-automation` owns deployment implementation. Report
+wrapper defects here and core template or script defects in the central
+repository.
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or
+services. Authorized use of Microsoft trademarks or logos is subject to and
+must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must
+not cause confusion or imply Microsoft sponsorship. Any use of third-party
+trademarks or logos is subject to those third parties' policies.

--- a/docs/01-00-prerequisites.md
+++ b/docs/01-00-prerequisites.md
@@ -1,0 +1,96 @@
+# Prepare Azure DevOps prerequisites
+
+## Outcome
+
+You have the access, identity, network, quota, software, and agent prerequisites
+required to bootstrap an SDAF Azure DevOps project.
+
+## Before you begin
+
+Confirm the target Azure tenant, subscriptions, Azure DevOps organization, and
+project naming. Complete architecture, network, DNS, quota, cost, and SAP
+software planning before you create resources.
+
+The automated setup path requires a local workstation with Windows PowerShell,
+Azure CLI updated by using `az upgrade`, and access to the current
+`SDAFUtilities` module. The utilities authenticate to Azure DevOps through
+`AZURE_DEVOPS_EXT_PAT` when that environment variable is present; otherwise,
+they can prompt for a personal access token (PAT).
+
+Review the current
+[Microsoft Learn prerequisites and setup methods](https://learn.microsoft.com/azure/sap/automation/configure-devops?tabs=linux)
+before you begin.
+
+## Inputs
+
+Record these values in an approved location:
+
+- Azure DevOps organization URL and project name.
+- Tenant ID and control-plane subscription ID.
+- Control-plane code and name.
+- Authentication method: service principal or managed identity.
+- Existing managed identity IDs or service-principal credentials, when used.
+- Agent pool name.
+- Azure regions, network address spaces, DNS ownership, and required private
+  connectivity.
+- SAP user credentials and selected BOM source for software acquisition.
+
+## Required access
+
+The bootstrap utilities create or update Azure DevOps projects, repositories,
+pipelines, variable groups, service connections, agent pools, permissions, and
+a wiki. The identity running them therefore needs corresponding Azure DevOps
+administration rights.
+
+When automatic Azure connection creation is selected, the utility assigns or
+uses Azure roles that include Contributor, Storage Blob Data Owner, Key Vault
+Administrator, Key Vault Secrets Officer, App Configuration Data Owner, and
+Network Contributor. Review these assignments with your security team and
+reduce scope where your approved deployment design permits.
+
+## Agent requirements
+
+1. Decide whether each pipeline stage will use Microsoft-hosted execution or an
+   approved self-hosted pool. Record the selected pool name.
+2. Confirm that the pool is authorized for every pipeline that uses it. The
+   bootstrap utility can create a pool and set pipeline permissions.
+3. Confirm that self-hosted agents can reach Azure Resource Manager, the target
+   subscriptions, storage, Key Vault, Azure Repos, and required SAP endpoints.
+4. Confirm that the agent workspace permits repository checkout and cleanup.
+   Core templates clean the workspace and use the Post Build Cleanup extension.
+5. Confirm that long-running installation jobs are allowed. The standard
+   installation template sets an unlimited job timeout.
+
+After these steps, the selected execution hosts meet the documented pipeline
+requirements.
+
+## Readiness check
+
+1. Sign in to Azure CLI with the identity that will run bootstrap. Verify that
+   the intended tenant and subscriptions are active.
+2. Verify Azure DevOps CLI access to the target organization. The organization
+   and project list commands must return without an authentication prompt or
+   authorization error.
+3. Verify that required resource providers, regional VM quota, IP address
+   ranges, DNS zones, and private connectivity are approved.
+4. Verify that SAP credentials can access the selected media and that credentials
+   will be stored as secret variables rather than committed to `WORKSPACES`.
+5. Estimate the cost of deployer, networking, storage, SAP infrastructure, and
+   optional Web application resources. Record the approval.
+6. Record the reviewed `sap-automation` and samples refs that the Azure DevOps
+   repositories will consume.
+
+## Review before execution
+
+PATs, service-principal secrets, and SAP credentials are sensitive. Do not put
+them in pipeline YAML, Terraform variable files, command history, or logs.
+Prefer short-lived bootstrap credentials and rotate them after project setup.
+
+## If it fails
+
+Use [Troubleshoot Azure DevOps deployments](troubleshooting.md) for PAT,
+permission, service-connection, agent, quota, networking, and DNS failures.
+
+## Next step
+
+[Bootstrap the Azure DevOps project](02-00-bootstrap.md).

--- a/docs/02-00-bootstrap.md
+++ b/docs/02-00-bootstrap.md
@@ -1,0 +1,152 @@
+# Bootstrap the Azure DevOps project
+
+## Outcome
+
+You have an Azure DevOps project with the configuration repository, code-source
+access, pipelines, cleanup task, agent pool, variable groups, service
+connections, and permissions required by SDAF.
+
+## Before you begin
+
+Complete [Prepare Azure DevOps prerequisites](01-00-prerequisites.md). Use
+[Configure Azure DevOps for SAP Deployment Automation](https://learn.microsoft.com/azure/sap/automation/configure-devops?tabs=linux)
+as the supported baseline.
+
+Choose one setup method:
+
+- **Automated scripts** create the project and baseline artifacts by using
+  `New-SDAFUserAssignedIdentity`, `New-SDAFADOProject`, and
+  `New-SDAFADOWorkloadZone`.
+- **Manual configuration** creates each Azure DevOps component through the
+  portal and repository imports.
+
+## Inputs
+
+Record the Azure DevOps organization URL, project name, tenant ID,
+control-plane and workload-zone subscription IDs, environment and region codes,
+managed-identity resource group, agent-pool name, SAP support credentials, and
+reviewed `sap-automation` branch.
+
+## Automated script path
+
+Run the current scripts from a local workstation with Windows PowerShell and
+the latest Azure CLI.
+
+1. [Configure the Azure DevOps project and control-plane artifacts](02-10-configure-devops-project.md).
+   This page includes the complete `New-SDAFUserAssignedIdentity` and
+   `New-SDAFADOProject` script.
+2. [Configure workload-zone artifacts](02-20-configure-workload-zone-artifacts.md).
+   This page includes the complete `Get-SDAFUserAssignedIdentity` and
+   `New-SDAFADOWorkloadZone` script.
+3. Return to this page and complete **Create optional control-plane samples**
+   when you need starter deployer and SAP library configuration.
+
+The scripts create Azure DevOps project artifacts, identities, variable groups,
+and service connections. They don't deploy the control plane or workload zone.
+
+### Create optional control-plane samples
+
+1. Open the **Create Sample Deployer Configuration** pipeline, which uses
+   `pipelines/22-sample-deployer-configuration.yml`.
+2. Select the region and approved optional components.
+3. Run the pipeline. It creates missing deployer and library examples and
+   updates selected wrapper defaults on the queued branch.
+4. Review every generated file and commit before merging it.
+
+The sample pipeline creates control-plane examples only. It is not a complete
+workload-zone or SAP-system configuration generator.
+
+## Manual configuration path
+
+Use this path when you need direct control over every Azure DevOps artifact.
+
+### Create the project and configuration repository
+
+1. Create a private Azure DevOps project and record its URL.
+2. Import
+   [`Azure/sap-automation-bootstrap`](https://github.com/Azure/sap-automation-bootstrap.git)
+   into the repository that has the same name as the project.
+3. If direct import is unavailable, create an empty Git repository, copy the
+   bootstrap repository content into a local clone, commit it, and push it.
+4. Verify `pipelines` and `WORKSPACES` exist in Azure Repos.
+
+### Choose the code source
+
+1. For Azure Repos-hosted code, import
+   [`Azure/sap-automation`](https://github.com/Azure/sap-automation.git) as
+   `sap-automation` and
+   [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples.git)
+   as `sap-samples`.
+2. For GitHub-hosted code, create a GitHub service connection and grant it to
+   the required pipelines.
+3. Verify `pipelines/resources.yml` resolves `sap-automation` and
+   `pipelines/resources_including_samples.yml` resolves both `sap-automation`
+   and `sap-samples`.
+
+### Create the pipelines
+
+1. Create an Azure Pipeline from each required YAML file under `pipelines`.
+2. Create deployment pipelines for `01`, `02`, `03`, the selected `04`
+   software-download wrapper, `05`, `10`, `11`, and `12`.
+3. Create maintenance pipelines `20`, `21`, and optional sample pipeline `22`
+   when your operating model uses them.
+4. Verify each pipeline points to the customer configuration repository and the
+   exact YAML path in [Pipeline reference](pipeline-reference.md).
+
+### Install the cleanup task
+
+1. Install
+   [Post Build Cleanup](https://marketplace.visualstudio.com/items?itemName=mspremier.PostBuildCleanup)
+   in the Azure DevOps organization.
+2. Verify the core pipeline tasks can resolve `PostBuildCleanup@4`.
+
+### Configure the agent
+
+1. Create a self-hosted agent pool when the deployment design requires it, and
+   grant the required pipelines access.
+2. Create a PAT with the Learn-documented Agent Pools, Build, Code, and Variable
+   Groups scopes. Store it securely.
+3. Deploy the control plane before manually configuring its deployer VM as an
+   Azure DevOps agent.
+4. If automatic agent configuration did not complete, run
+   `deploy/scripts/configure_deployer.sh`, reboot the deployer, and run
+   `deploy/scripts/setup_ado.sh` as described in the Learn article.
+5. Verify the agent is online in the selected pool.
+
+### Configure variable groups
+
+1. Create `SDAF-General` with `Deployment_Configuration_Path=WORKSPACES`, the
+   reviewed branch and tool versions, `S-Username`, and secret `S-Password`.
+2. Create `SDAF-<environment>` for each control-plane or workload environment.
+3. Add the approved identity, subscription, tenant, service-connection, agent,
+   state, Key Vault, and optional Web application values required by that
+   environment.
+4. Grant the required pipelines permission to use every group.
+
+### Configure service connections and permissions
+
+1. Create an Azure Resource Manager service connection for each target
+   subscription and verify its credentials.
+2. Grant the required pipelines access to each service connection.
+3. Grant the project Build Service **Contribute** permission on the
+   configuration repository because pipelines create or update files.
+4. If the Web application is enabled, verify the Build Service also has the
+   repository access required by the application.
+
+## Validate
+
+1. Open every pipeline and confirm its YAML path resolves.
+2. Confirm both repository resource files resolve their declared repositories.
+3. Confirm the cleanup task and selected agent are available.
+4. Confirm variable groups and service connections are authorized.
+5. Confirm no credential value appears in source control or pipeline logs.
+
+## If it fails
+
+Inventory the resources already created before rerunning an automated utility.
+Correct the first failed permission, repository, connection, or agent
+dependency. See [Troubleshoot Azure DevOps deployments](troubleshooting.md).
+
+## Next step
+
+[Deploy the control plane](03-00-control-plane.md).

--- a/docs/02-10-configure-devops-project.md
+++ b/docs/02-10-configure-devops-project.md
@@ -1,0 +1,146 @@
+# Configure the Azure DevOps project and control-plane artifacts
+
+Use the SDAF PowerShell utilities to create the Azure DevOps project and the
+baseline artifacts required for control-plane deployment.
+
+## Outcome
+
+You have an Azure DevOps project with a configuration repository, pipelines,
+variable groups, service connections, an agent pool, and permissions for the
+SDAF control plane.
+
+This procedure configures Azure DevOps. It doesn't deploy the control plane.
+
+## Before you begin
+
+Complete [Prepare Azure DevOps prerequisites](01-00-prerequisites.md). Run this
+procedure from a local workstation with Windows PowerShell and the latest Azure
+CLI.
+
+You need:
+
+- permission to create Azure resources and Azure DevOps project assets;
+- the Azure DevOps organization URL;
+- tenant and control-plane subscription IDs;
+- approved control-plane and region codes;
+- an agent-pool name; and
+- SAP support credentials when software acquisition is in scope.
+
+## Configure the script
+
+1. Open Windows PowerShell.
+2. Copy the following script into a local `.ps1` file.
+3. Replace every placeholder value with the approved value for your
+   environment.
+4. Set `$repo` and `$branch` to the reviewed SDAF source. The script downloads
+   `SDAFUtilities` from that ref.
+5. Remove `-EnableWebApp` when the configuration Web application isn't in
+   scope.
+
+```powershell
+# Azure DevOps configuration
+$AzureDevOpsOrganizationUrl = "https://dev.azure.com/ORGANIZATIONNAME"
+
+# Azure infrastructure configuration
+$ControlPlaneCode = "MGMT"
+$ControlPlaneRegionCode = "SECE"
+$Location = "swedencentral"
+
+$ControlPlaneName = "$ControlPlaneCode-$ControlPlaneRegionCode-DEP01"
+$AzureDevOpsProjectName = "SDAF-" + $ControlPlaneCode + "-" + $ControlPlaneRegionCode
+
+$ControlPlaneSubscriptionId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$TenantId = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+
+# SAP support credentials
+$Env:SUserName = Read-Host "Enter the SAP support user ID"
+$SecureSPassword = Read-Host "Enter the SAP support user password" -AsSecureString
+$Env:SPassword = (New-Object System.Net.NetworkCredential("", $SecureSPassword)).Password
+
+# Managed identity and Azure DevOps agent configuration
+$MSIResourceGroupName = "SDAF-MSIs"
+$AgentPoolName = "SDAF-$ControlPlaneCode-$ControlPlaneRegionCode-POOL"
+
+# SDAF source
+$repo = "Azure/sap-automation"
+$branch = "main"
+
+Remove-Module SDAFUtilities -ErrorAction SilentlyContinue
+
+$url = "https://raw.githubusercontent.com/$repo/refs/heads/$branch/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1"
+
+Write-Host "Downloading SDAFUtilities module from $url" -ForegroundColor Green
+
+Invoke-WebRequest -Uri $url -OutFile "SDAFUtilities.psm1"
+Unblock-File -Path ".\SDAFUtilities.psm1"
+Import-Module ".\SDAFUtilities.psm1"
+
+$ManagedServiceIdentity = New-SDAFUserAssignedIdentity `
+    -ManagedIdentityName "$ControlPlaneName" `
+    -ResourceGroupName $MSIResourceGroupName `
+    -SubscriptionId $ControlPlaneSubscriptionId `
+    -Location $Location `
+    -Verbose
+
+try {
+    New-SDAFADOProject `
+        -AdoOrganization $AzureDevOpsOrganizationUrl `
+        -AdoProject $AzureDevOpsProjectName `
+        -TenantId $TenantId `
+        -ControlPlaneCode $ControlPlaneCode `
+        -ControlPlaneSubscriptionId $ControlPlaneSubscriptionId `
+        -ControlPlaneName $ControlPlaneName `
+        -AuthenticationMethod "Managed Identity" `
+        -AgentPoolName $AgentPoolName `
+        -ManagedIdentityObjectId $ManagedServiceIdentity.PrincipalId `
+        -CreateConnections `
+        -EnableWebApp `
+        -GitHubRepoName $repo `
+        -BranchName $branch `
+        -Verbose
+}
+finally {
+    Remove-Item Env:SUserName -ErrorAction SilentlyContinue
+    Remove-Item Env:SPassword -ErrorAction SilentlyContinue
+}
+
+Write-Output "Azure DevOps project '$AzureDevOpsProjectName' created successfully."
+Write-Output "Managed identity ID: $($ManagedServiceIdentity.IdentityId)"
+Write-Output "Agent pool name: $AgentPoolName"
+```
+
+> [!NOTE]
+> The current utility reads the SAP password from `SPassword`. The script
+> converts the securely entered value only for the utility call and removes both
+> credential environment variables afterward.
+
+## Run the script
+
+1. Run `az upgrade`, and then sign in to the intended Azure tenant.
+2. Run the `.ps1` file.
+3. Complete each browser authentication prompt opened by the utilities.
+4. Wait for `New-SDAFADOProject` to finish before closing PowerShell.
+5. Record the project URL, managed identity ID, and agent-pool name.
+
+## Validate
+
+In Azure DevOps, confirm that:
+
+1. The project exists with the expected name.
+2. The configuration repository contains `pipelines` and `WORKSPACES`.
+3. The deployment pipelines were created.
+4. `SDAF-General` and the control-plane variable group exist.
+5. The expected service connections exist and target the correct subscription.
+6. The agent pool exists and pipeline permissions are configured.
+7. The Build Service has the repository permissions required by the pipelines.
+8. No SAP password, PAT, or Azure credential appears in source control or logs.
+
+## If it fails
+
+Don't rerun the script before checking which resources were created. Correct
+the first failed permission, identity, repository, pipeline, or connection.
+Then rerun the script with the same project and control-plane names.
+
+## Next step
+
+[Configure workload-zone artifacts](02-20-configure-workload-zone-artifacts.md).

--- a/docs/02-20-configure-workload-zone-artifacts.md
+++ b/docs/02-20-configure-workload-zone-artifacts.md
@@ -1,0 +1,132 @@
+# Configure workload-zone artifacts
+
+Use the SDAF PowerShell utilities to create the variable group and service
+connection required for a new workload zone.
+
+## Outcome
+
+Your Azure DevOps project contains an environment-specific variable group and
+service connection for the workload-zone subscription.
+
+This procedure configures Azure DevOps artifacts. It doesn't create the
+workload-zone Terraform configuration or deploy Azure infrastructure.
+
+## Before you begin
+
+Complete
+[Configure the Azure DevOps project and control-plane artifacts](02-10-configure-devops-project.md).
+Confirm that the control-plane managed identity and Azure DevOps project exist.
+
+You need:
+
+- the Azure DevOps organization URL and project name;
+- tenant, control-plane subscription, and workload-zone subscription IDs;
+- the control-plane managed identity name and resource group;
+- approved control-plane, workload-zone, and region codes; and
+- permission to create variable groups and service connections.
+
+## Configure the script
+
+1. Open Windows PowerShell.
+2. Copy the following script into a local `.ps1` file.
+3. Replace every placeholder value with the values used for the existing
+   control plane and the new workload zone.
+4. Set `$repo` and `$branch` to the same reviewed SDAF source used to configure
+   the project.
+
+```powershell
+# Azure DevOps configuration
+$AzureDevOpsOrganizationUrl = "https://dev.azure.com/ORGANIZATIONNAME"
+
+# Azure infrastructure configuration
+$ControlPlaneCode = "MGMT"
+$ControlPlaneRegionCode = "SECE"
+$Location = "swedencentral"
+
+$ControlPlaneName = "$ControlPlaneCode-$ControlPlaneRegionCode-DEP01"
+$ManagedIdentityName = "$ControlPlaneName"
+$MSIResourceGroupName = "SDAF-MSIs"
+
+$AzureDevOpsProjectName = "SDAF-" + $ControlPlaneCode + "-" + $ControlPlaneRegionCode
+
+$ControlPlaneSubscriptionId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$WorkloadSubscriptionId = "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"
+$TenantId = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+
+$WorkloadCode = "TEST"
+$WorkloadRegionCode = "SECE"
+$WorkloadZoneCode = "$WorkloadCode-$WorkloadRegionCode-SAP01"
+
+# SDAF source
+$repo = "Azure/sap-automation"
+$branch = "main"
+
+Remove-Module SDAFUtilities -ErrorAction SilentlyContinue
+
+$url = "https://raw.githubusercontent.com/$repo/refs/heads/$branch/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1"
+
+Write-Host "Downloading SDAFUtilities module from $url" -ForegroundColor Green
+
+Invoke-WebRequest -Uri $url -OutFile "SDAFUtilities.psm1"
+Unblock-File -Path ".\SDAFUtilities.psm1"
+Import-Module ".\SDAFUtilities.psm1"
+
+$ManagedServiceIdentity = Get-SDAFUserAssignedIdentity `
+    -ManagedIdentityName $ManagedIdentityName `
+    -ResourceGroupName $MSIResourceGroupName `
+    -SubscriptionId $ControlPlaneSubscriptionId `
+    -Verbose
+
+Write-Output "Managed identity ID: $($ManagedServiceIdentity.IdentityId)"
+
+New-SDAFADOWorkloadZone `
+    -AdoOrganization $AzureDevOpsOrganizationUrl `
+    -AdoProject $AzureDevOpsProjectName `
+    -TenantId $TenantId `
+    -ControlPlaneCode $ControlPlaneCode `
+    -WorkloadZoneCode $WorkloadZoneCode `
+    -WorkloadZoneSubscriptionId $WorkloadSubscriptionId `
+    -AuthenticationMethod "Managed Identity" `
+    -ManagedIdentityObjectId $ManagedServiceIdentity.PrincipalId `
+    -ManagedIdentityId $ManagedServiceIdentity.IdentityId `
+    -ControlPlaneSubscriptionId $ControlPlaneSubscriptionId `
+    -CreateConnections `
+    -Verbose
+```
+
+## Run the script
+
+1. Sign in to the Azure tenant that contains the control-plane managed identity.
+2. Run the `.ps1` file.
+3. Complete each browser authentication prompt opened by the utilities.
+4. Confirm that the returned managed identity is the control-plane identity.
+5. Wait for `New-SDAFADOWorkloadZone` to finish.
+
+## Validate
+
+In Azure DevOps, confirm that:
+
+1. `SDAF-<workload-environment>` exists in **Pipelines** > **Library**.
+2. The variable group contains the intended workload-zone subscription and
+   identity values.
+3. Sensitive variables are marked as secret.
+4. The workload-zone service connection exists and targets the intended
+   subscription.
+5. The required pipelines are authorized to use the variable group and service
+   connection.
+
+The script doesn't create
+`WORKSPACES/LANDSCAPE/<workload-zone>/<workload-zone>.tfvars`. Prepare that
+file before you run the workload-zone deployment pipeline.
+
+## If it fails
+
+Confirm the project name, managed identity, subscription IDs, and Azure DevOps
+permissions before rerunning the script. Reuse the same workload-zone code so
+you don't create duplicate environment artifacts.
+
+## Next step
+
+Return to [Bootstrap the Azure DevOps project](02-00-bootstrap.md), or continue
+to [Deploy the control plane](03-00-control-plane.md) when project setup is
+complete.

--- a/docs/03-00-control-plane.md
+++ b/docs/03-00-control-plane.md
@@ -49,7 +49,8 @@ rewrites defaults in selected pipeline wrappers.
 The core template prepares the execution agent, stores deployment credentials
 in Key Vault, deploys the control plane, and optionally builds and deploys the
 configuration Web application. Repository checkouts map the core repository to
-`/sap-automation` and this repository to `/config`.
+`$(Build.SourcesDirectory)/sap-automation` and this repository to
+`$(Build.SourcesDirectory)/config`.
 
 ## Review before execution
 

--- a/docs/03-00-control-plane.md
+++ b/docs/03-00-control-plane.md
@@ -1,0 +1,116 @@
+# Deploy the control plane
+
+## Outcome
+
+You have deployed the SDAF deployer and SAP library. If selected, you also have
+the configuration Web application infrastructure and software.
+
+## Before you begin
+
+Complete [Bootstrap the Azure DevOps project](02-00-bootstrap.md). Confirm that
+`SDAF-General` and `SDAF-<control-plane>` contain valid identity, subscription,
+agent, and version values.
+
+## Inputs
+
+- Deployer configuration name:
+  `ENV-LOCA-VNET-INFRASTRUCTURE`.
+- Library configuration name: `ENV-LOCA-SAP_LIBRARY`.
+- Control-plane environment name, such as `MGMT-WEEU-DEP00`.
+- `WORKSPACES/DEPLOYER/<deployer>/<deployer>.tfvars`.
+- `WORKSPACES/LIBRARY/<library>/<library>.tfvars`.
+- Decisions for the Web application, self-hosted execution, reset, and test
+  parameters.
+
+## Prepare configuration
+
+Pipeline `22-sample-deployer-configuration.yml` can create deployer and library
+examples when the target files do not exist. It also commits the files and
+rewrites defaults in selected pipeline wrappers.
+
+1. Create a review branch in the customer configuration repository.
+2. Queue `22-sample-deployer-configuration.yml` with the approved environment,
+   region, network, and optional-service choices. The pipeline creates or
+   preserves the control-plane files and pushes configuration-repository
+   commits.
+3. Review every generated Terraform value. Replace sample address spaces, DNS
+   labels, resource choices, identity settings, and subscription values with
+   approved production values.
+4. Review the wrapper-default changes committed by pipeline `22`. Confirm that
+   they match the intended deployer, library, workload-zone, and region names.
+5. Merge the reviewed configuration through your normal branch policy.
+
+## What the automation does
+
+`pipelines/01-deploy-control-plane.yml` is a wrapper. It loads variable group
+`SDAF-<environment>` and extends
+`deploy/pipelines/01-deploy-control-plane.yaml` from `sap-automation`.
+
+The core template prepares the execution agent, stores deployment credentials
+in Key Vault, deploys the control plane, and optionally builds and deploys the
+configuration Web application. Repository checkouts map the core repository to
+`/sap-automation` and this repository to `/config`.
+
+## Review before execution
+
+The default wrapper enables both Web application options. Set them to `false`
+when they are not approved. The `reset` option forces reinstallation and the
+pipeline text warns that it can require multiple runs; do not use it as a
+general retry option.
+
+> [!WARNING]
+> The wrapper labels `test` as a no-change option, but the validated core
+> template does not pass that parameter to the deployment scripts. Do not use
+> `test: true` as a plan or safety gate. Treat every run as state-changing.
+
+## Run
+
+1. Review the approved configuration commit, subscription, service connection,
+   selected agent, and optional features. Record the approval evidence.
+2. Queue `01-deploy-control-plane.yml` with the exact reviewed deployer,
+   library, and environment names. The pipeline begins state-changing
+   preparation and deployment.
+3. Monitor **Prepare the self hosted agent**, **Save the Deployment
+   Credentials**, and **Deploy the control plane**. If enabled, also monitor
+   **Deploy SAP configuration Web App**.
+
+## Configure the optional Web application
+
+The Learn-supported journey can provision Web application infrastructure
+during control-plane deployment and deploy the application software from the
+same core template.
+
+1. Create or verify the Microsoft Entra app registration and store its client
+   secret securely.
+2. Set the approved app registration and Web application values in the
+   control-plane variable group.
+3. Enable both Web application parameters when queuing pipeline `01`.
+4. After deployment, complete the application registration redirect URI and
+   subscription Reader role steps in the
+   [Learn article](https://learn.microsoft.com/azure/sap/automation/configure-devops?tabs=linux#deploy-the-control-plane-web-application).
+5. Verify the Web application opens and can resolve the Azure DevOps project,
+   repository, pipelines, and variable group.
+
+## Validate
+
+1. Verify the deployer and SAP library resource groups and expected resources in
+   Azure.
+2. Verify the remote Terraform state keys for the deployer and library are
+   present in the approved state storage account.
+3. Verify the deployer Key Vault and storage access through the pipeline
+   identity.
+4. Verify the selected agent pool is available for later workload-zone and
+   installation stages.
+5. If enabled, open the configuration Web application and verify that its
+   project, repository, pipeline, and variable-group settings are correct.
+
+## If it fails
+
+Preserve the configuration commit, state, and failed run logs. Correct the
+first failed stage, then rerun with the same identifiers. Do not enable `reset`
+unless release guidance requires reinstallation and you have reviewed its
+effects.
+
+## Next step
+
+[Deploy a workload zone](04-00-workload-zone.md).

--- a/docs/04-00-workload-zone.md
+++ b/docs/04-00-workload-zone.md
@@ -1,0 +1,92 @@
+# Deploy a workload zone
+
+## Outcome
+
+You have a deployed SDAF workload zone connected to the existing control plane.
+
+## Before you begin
+
+Complete [Deploy the control plane](03-00-control-plane.md). Verify that the
+control-plane state, Key Vault, service connection, and selected agent are
+available.
+
+## Inputs
+
+- Workload-zone configuration name:
+  `ENV-LOCA-VNET-INFRASTRUCTURE`.
+- Workload environment name: `ENV-LOCA-VNET`.
+- Deployer environment and region code.
+- `WORKSPACES/LANDSCAPE/<workload-zone>/<workload-zone>.tfvars`.
+- Decision for inheriting control-plane state settings.
+- `SDAF-<workload-environment>` variable group.
+
+## Prepare configuration
+
+No verified full Azure DevOps equivalent exists for GitHub configuration
+workflow `02`.
+
+1. Copy a matching workload-zone example from
+   [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples/tree/main/Terraform/WORKSPACES/LANDSCAPE),
+   export it from the SDAF configuration Web application where applicable, or
+   create it through reviewed direct editing.
+2. Store the file under `WORKSPACES/LANDSCAPE` using the exact configuration
+   name that you will pass to pipeline `02`.
+3. Review subscription, network, DNS, peering, Key Vault, state, sizing, and
+   availability-zone values. The file must describe the approved environment.
+4. Complete
+   [Configure workload-zone artifacts](02-20-configure-workload-zone-artifacts.md)
+   when the workload environment needs its Azure DevOps variable group or
+   service connection. Verify the resulting `SDAF-<workload-environment>`
+   group.
+5. Commit and approve the configuration before queuing deployment.
+
+## What the automation does
+
+`pipelines/02-sap-workload-zone.yml` wraps
+`deploy/pipelines/02-sap-workload-zone.yaml`. The core template first stores
+deployment credentials in the deployer Key Vault. It then runs the workload-zone
+deployment script with the prepared configuration. When `inherit_settings` is
+`true`, the template derives state information from the control plane.
+
+## Review before execution
+
+Confirm that `workload_environment_parameter` and `workload_zone` identify the
+same environment. Confirm the deployer environment and region point to the
+control plane already deployed.
+
+> [!WARNING]
+> The credential-storage stage runs before the plan stage. Protect the
+> associated variable group and Key Vault even when `test: true`.
+
+## Run
+
+1. Queue `02-sap-workload-zone.yml` with `test: true` and the reviewed names.
+   `TEST_ONLY=true` reaches `installer.sh` or `installer_v2.sh`, which exits
+   after Terraform plan without applying it.
+2. Review the plan for replacements, deletion, subscription, state, network,
+   DNS, and sizing changes.
+3. Obtain approval and retain the reviewed run link.
+4. Queue the same pipeline with `test: false` and unchanged identifiers.
+5. Monitor **Save the Deployment Credentials** and **Deploy SAP workload zone**.
+
+## Validate
+
+1. Verify the workload-zone resource groups, network resources, and shared
+   services in Azure.
+2. Verify the workload-zone Terraform state exists in the approved storage
+   account and is separate from control-plane state.
+3. Verify connectivity from the selected agent and deployer to workload-zone
+   resources.
+4. Verify DNS resolution, routing, peering, and Key Vault access required by the
+   planned SAP systems.
+
+## If it fails
+
+Do not recreate configuration with a different name. Preserve state and logs,
+correct the failing dependency, and rerun with the same identifiers. If the
+credential-storage stage failed, resolve that stage before attempting the
+deployment stage.
+
+## Next step
+
+[Deploy SAP-system infrastructure](05-00-sap-system.md).

--- a/docs/05-00-sap-system.md
+++ b/docs/05-00-sap-system.md
@@ -1,0 +1,88 @@
+# Deploy SAP-system infrastructure
+
+## Outcome
+
+You have deployed the Azure infrastructure for one SAP system in an existing
+workload zone.
+
+## Before you begin
+
+Complete [Deploy a workload zone](04-00-workload-zone.md). Verify the
+workload-zone network, DNS, Key Vault, Terraform state, and variable group.
+
+## Inputs
+
+- SAP-system configuration name: `ENV-LOCA-VNET-SID`.
+- Workload environment name: `ENV-LOCA-VNET`.
+- `WORKSPACES/SYSTEM/<sap-system>/<sap-system>.tfvars`.
+- `SDAF-<workload-environment>` variable group.
+- Approved SAP topology, database platform, VM sizing, storage, availability,
+  and network design.
+
+## Prepare configuration
+
+No verified full Azure DevOps equivalent exists for GitHub configuration
+workflow `04`.
+
+1. Copy a matching SAP-system example from
+   [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples/tree/main/Terraform/WORKSPACES/SYSTEM),
+   export it from the SDAF configuration Web application where applicable, or
+   create it through reviewed direct editing.
+2. Store the file under `WORKSPACES/SYSTEM` using the exact configuration name
+   that you will pass to pipeline `03`.
+3. Review the system identifier, database platform, host counts, VM sizes,
+   storage, zones, subnets, load balancers, and high-availability settings.
+4. Confirm the design fits the deployed workload-zone address space and the
+   available regional quota.
+5. Commit and approve the configuration before queuing deployment.
+
+## What the automation does
+
+`pipelines/03-sap-system-deployment.yml` wraps
+`deploy/pipelines/03-sap-system-deployment.yaml`. The core template checks out
+the core and configuration repositories, installs the configured Terraform
+version, and runs the SAP-system deployment script. It uses the workload-zone
+variable group and remote state information.
+
+## Review before execution
+
+Topology changes can create, resize, or replace infrastructure. Review the
+configuration for replacement or deletion risk. Confirm that the environment
+parameter is the workload environment, not the full SAP-system name.
+
+> [!WARNING]
+> A plan can expose replacement or deletion risk. Do not run the apply until
+> the plan has been reviewed and approved.
+
+## Run
+
+1. Queue `03-sap-system-deployment.yml` with `test: true`, the reviewed
+   SAP-system name, and the workload environment. `TEST_ONLY=true` reaches
+   `installer.sh` or `installer_v2.sh`, which exits after Terraform plan.
+2. Review the plan for replacements, deletion, topology, subscription, state,
+   and sizing changes.
+3. Obtain approval and retain the reviewed run link.
+4. Queue the same pipeline with `test: false` and unchanged identifiers.
+5. Monitor **Deploy SAP infrastructure** until the Terraform operation and
+   pipeline complete.
+
+## Validate
+
+1. Verify the expected SAP-system resource groups, virtual machines, disks,
+   load balancers, and network interfaces in Azure.
+2. Verify the SAP-system Terraform state exists in the approved state storage
+   account.
+3. Verify host reachability from the selected deployer agent.
+4. Verify the installation pipeline can resolve its inventory inputs and
+   required secrets without exposing secret values.
+5. Verify the deployed topology matches the reviewed design.
+
+## If it fails
+
+Preserve the Terraform state and run logs. Correct the first failing resource or
+permission, then rerun with the same system and environment names. Do not delete
+the state or use the ARM fallback pipeline to recover a normal deployment.
+
+## Next step
+
+[Acquire SAP software and run installation](06-00-software-and-installation.md).

--- a/docs/06-00-software-and-installation.md
+++ b/docs/06-00-software-and-installation.md
@@ -1,0 +1,109 @@
+# Acquire SAP software and run installation
+
+## Outcome
+
+You have downloaded the selected SAP software into the SAP library and run the
+approved operating-system, database, and SAP installation stages.
+
+## Before you begin
+
+Complete [Deploy SAP-system infrastructure](05-00-sap-system.md). Confirm
+network access to SAP download endpoints and target hosts. Set `S-Username` and
+secret `S-Password` in `SDAF-General`.
+
+The canonical SAP definitions and BOM files are owned by
+[`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples).
+
+## Inputs
+
+- Control-plane environment and region.
+- Approved application, database, kernel, or combined BOM name.
+- SAP-system configuration name and workload environment.
+- Database platform.
+- Installation-stage selections.
+- Optional Ansible extra parameters.
+
+## Select a software-download wrapper
+
+Two wrappers call the same core software-download template. Their public
+support status is not confirmed, so do not infer a preferred option from the
+filenames.
+
+- `04-sap-software-download.yml` selects one combined BOM from its list, accepts
+  an override name, and requires an explicit region.
+- `04-sap-software-download_v2.yml` selects separate application, database, and
+  kernel BOMs, constructs a combined BOM name, and derives the region from the
+  environment name.
+
+Use the wrapper identified by your reviewed release guidance. Verify that its
+listed BOM values exist in the checked-out samples repository.
+
+## What the automation does
+
+Both `04` wrappers extend `resources_including_samples.yml`, which declares
+`sap-automation` and `sap-samples`, and call
+`deploy/pipelines/04-sap-software-download.yaml`. The core template checks out
+the core, samples, and configuration repositories. It installs Terraform and
+Ansible, prepares the selected BOM with SAP credentials, and runs the software
+download. The download job has no pipeline timeout.
+
+`05-DB-and-SAP-installation.yml` extends the core installation template. It can
+run parameter validation, base OS configuration, SAP OS configuration, BOM
+processing, database installation, central services, database load, high
+availability, primary and additional application servers, Web Dispatcher,
+post-configuration actions, quality checks, ACSS registration, and AMS
+provider creation.
+
+## Review before execution
+
+SAP software licensing and media access remain your responsibility. Never put
+SAP credentials in BOM or Terraform files. Review all installation booleans;
+most stages default to `true`, while some optional post-installation stages
+default to `false`.
+
+## Download software
+
+1. Confirm the selected BOM definitions exist in the samples repository ref
+   used by Azure DevOps.
+2. Confirm the wrapper can resolve the `sap-samples` checkout through its
+   repository resources.
+3. Queue the approved `04` wrapper with the control-plane environment, BOM
+   selections, platform, and `re_download: false`.
+4. Monitor **Preparation** and **Download software**. The preparation stage
+   resolves the BOM, Key Vault, and SAP username for the download stage.
+5. Verify the expected media is present in the SAP library storage and that the
+   run contains no credential values.
+6. Set `re_download: true` only when you deliberately need the core downloader
+   to acquire the media again.
+
+## Run installation
+
+1. Queue `05-DB-and-SAP-installation.yml` with the exact SAP-system name,
+   workload environment, and BOM.
+2. Disable every stage that is outside the approved change. The selected
+   booleans determine which Ansible playbooks run.
+3. Review the parameter-validation result before later installation tasks
+   continue.
+4. Monitor each selected task and record the first failed play and host if the
+   run stops.
+5. Verify operating-system configuration, database services, SAP central
+   services, application instances, and optional components selected for the
+   run.
+
+## SAP CAL wrapper
+
+`07-sap-cal-installation.yml` references
+`deploy/pipelines/07-sap-cal-installation.yaml`, which was not present in the
+validated core checkout. Do not queue this wrapper until the `sap-automation`
+repository ref used by Azure DevOps contains the template and your release has
+validated the CAL path.
+
+## If it fails
+
+Do not rerun every installation stage by default. Correct the failed host,
+credential, media, or playbook input. Then queue pipeline `05` with completed
+stages disabled and only the required recovery stages enabled.
+
+## Next step
+
+[Operate and remove SDAF deployments](07-00-operations.md).

--- a/docs/07-00-operations.md
+++ b/docs/07-00-operations.md
@@ -1,0 +1,109 @@
+# Operate and remove SDAF deployments
+
+## Outcome
+
+You can update repository content, rotate credentials, diagnose failed runs,
+and remove SDAF resources in dependency order.
+
+## Before you begin
+
+Back up configuration and confirm access to remote Terraform state. Review
+every source ref before an update and every resource name before removal.
+
+## Update repositories
+
+`20-update-repositories.yml` is a standalone pipeline. It pulls core
+`sap-automation` content and sample content from the configured GitHub
+repositories into Azure Repos and pushes the result.
+
+1. Record the current Azure Repos commit IDs and create a recovery branch or
+   tag.
+2. Queue `20-update-repositories.yml` with the reviewed source repository,
+   sample repository, branch, and tag values.
+3. Keep `force: false` for normal updates. The pipeline performs a Git pull and
+   push for each repository.
+4. Review merge conflicts and the resulting commits before running deployment
+   pipelines.
+
+> [!WARNING]
+> `force: true` performs a force push. Use it only through an approved recovery
+> process because it can discard Azure Repos history.
+
+## Update wrapper pipelines
+
+`21-update-pipelines.yml` is a standalone pipeline. It checks selected wrapper
+files out of the configured bootstrap source repository and pushes them to the
+target branch.
+
+1. Back up customer changes under `pipelines`.
+2. Review the source repository's `main` versions of the files enumerated in
+   pipeline `21`.
+3. Queue the pipeline with `force: false`.
+4. Review the resulting commit before using an updated wrapper.
+
+Pipeline `21` does not enumerate every current wrapper. It does not copy
+`04-sap-software-download_v2.yml` or `07-sap-cal-installation.yml`. Review those
+files separately during updates.
+
+> [!WARNING]
+> `force: true` force-pushes the selected branch and can discard target history.
+
+## Regenerate control-plane examples
+
+Pipeline `22-sample-deployer-configuration.yml` commits generated files and
+wrapper-default replacements directly to the queued branch.
+
+1. Create a review branch before queuing pipeline `22`.
+2. Record whether the deployer and library target files already exist. The
+   pipeline preserves existing files but still rewrites selected wrapper
+   defaults.
+3. Queue the pipeline with approved values.
+4. Review every generated commit before merging.
+
+## Rotate credentials
+
+1. Update the Azure service connection or managed identity through the approved
+   Azure DevOps and Azure process.
+2. Update secret variables through Azure DevOps Library without printing their
+   values.
+3. Verify the affected `SDAF-<environment>` group still points to the intended
+   tenant, subscription, connection, and agent.
+4. Validate the rotated identity with an approved access check. For workload
+   zones or SAP systems, use pipeline `02` or `03` with `test: true` to verify
+   Terraform planning before an apply.
+
+## Remove resources
+
+Remove dependents before shared infrastructure: SAP systems, workload zones,
+then the control plane.
+
+1. Back up configuration, state, and required data.
+2. Queue `10-remover-terraform.yml` for the SAP system with
+   `cleanup_sap: true` and `cleanup_zone: false`.
+3. Verify the SAP-system resources are removed and state reflects the completed
+   Terraform destroy.
+4. Queue pipeline `10` for the workload zone only after all dependent SAP
+   systems are removed.
+5. Verify the workload-zone resources are removed and control-plane resources
+   remain.
+6. Queue `12-remove-control-plane.yml` only after every dependent workload zone
+   is removed.
+7. Verify both control-plane removal stages complete and the intended state and
+   shared resources are removed.
+
+> [!WARNING]
+> `11-remover-arm-fallback.yml` deletes resource groups through Azure Resource
+> Manager and removes deployment artifacts from `WORKSPACES`. Its wrapper
+> defaults enable SAP-system, workload-zone, and control-plane cleanup. Use it
+> only as a reviewed last resort after Terraform removal fails.
+
+## If it fails
+
+Stop at the first failed dependency. Do not continue to remove a parent layer
+while child resources or state remain. Preserve logs and state, then use
+[Troubleshoot Azure DevOps deployments](troubleshooting.md).
+
+## Next step
+
+Use [Pipeline reference](pipeline-reference.md) for wrapper details or return to
+the [central SDAF hub](https://github.com/Azure/sap-automation).

--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -10,8 +10,8 @@ All pipeline files in this repository use `trigger: none`.
 
 | File | Repositories | Agent paths |
 | --- | --- | --- |
-| `pipelines/resources.yml` | `sap-automation` | Core `/sap-automation`; self `/config` |
-| `pipelines/resources_including_samples.yml` | `sap-automation`, `sap-samples` | Core `/sap-automation`; samples `/samples`; self `/config` |
+| `pipelines/resources.yml` | `sap-automation` | Core `$(Build.SourcesDirectory)/sap-automation`; self `$(Build.SourcesDirectory)/config` |
+| `pipelines/resources_including_samples.yml` | `sap-automation`, `sap-samples` | Core `$(Build.SourcesDirectory)/sap-automation`; samples `$(Build.SourcesDirectory)/samples`; self `$(Build.SourcesDirectory)/config` |
 
 Both resource files currently use `ref: main`. The two software-download
 wrappers correctly use `resources_including_samples.yml`.

--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -1,0 +1,69 @@
+# Azure DevOps pipeline reference
+
+This page identifies wrapper ownership and implementation ownership. A wrapper
+in this repository supplies customer-facing parameters and repository wiring.
+A core template in `Azure/sap-automation` implements deployment behavior.
+
+All pipeline files in this repository use `trigger: none`.
+
+## Repository resources
+
+| File | Repositories | Agent paths |
+| --- | --- | --- |
+| `pipelines/resources.yml` | `sap-automation` | Core `/sap-automation`; self `/config` |
+| `pipelines/resources_including_samples.yml` | `sap-automation`, `sap-samples` | Core `/sap-automation`; samples `/samples`; self `/config` |
+
+Both resource files currently use `ref: main`. The two software-download
+wrappers correctly use `resources_including_samples.yml`.
+
+## Deployment wrappers
+
+| Wrapper | Core template | Key parameters | Result and limitations |
+| --- | --- | --- | --- |
+| `01-deploy-control-plane.yml` | `deploy/pipelines/01-deploy-control-plane.yaml` | `deployer`, `library`, `environment`, Web application options, `use_deployer`, `reset`, `test` | Deploys control-plane resources and optional Web application. Loads `SDAF-<environment>`. `reset` can require multiple runs. The core template does not pass `test` to deployment scripts. |
+| `02-sap-workload-zone.yml` | `deploy/pipelines/02-sap-workload-zone.yaml` | Workload-zone and environment names, deployer environment and region, `inherit_settings`, `test` | Stores credentials in Key Vault and deploys the workload zone. `test: true` reaches the v1 or v2 installer and exits after Terraform plan. No stage-specific configuration generator is included. |
+| `03-sap-system-deployment.yml` | `deploy/pipelines/03-sap-system-deployment.yaml` | `sap_system`, `environment`, `test` | Deploys SAP-system infrastructure from prepared `SYSTEM` configuration. `test: true` reaches the v1 or v2 installer and exits after Terraform plan. No stage-specific configuration generator is included. |
+| `04-sap-software-download.yml` | `deploy/pipelines/04-sap-software-download.yaml` | Combined BOM, override, environment, region, extra parameters, `re_download` | Downloads a selected combined BOM. Public selection criteria versus `_v2` are unresolved. |
+| `04-sap-software-download_v2.yml` | `deploy/pipelines/04-sap-software-download.yaml` | Application, database, and kernel BOMs, platform, combined name, environment, extra parameters, `re_download` | Constructs a combined BOM and derives region from the environment. Public selection criteria versus the other wrapper are unresolved. |
+| `05-DB-and-SAP-installation.yml` | `deploy/pipelines/05-DB-and-SAP-installation.yaml` | System, environment, BOM, stage booleans, extra parameters | Runs parameter validation and selected Ansible installation stages. The core job has no timeout. |
+| `07-sap-cal-installation.yml` | `deploy/pipelines/07-sap-cal-installation.yaml` | System, environment, CAL product, OS and CAL options, ACSS values | The referenced core template was absent from the validated core checkout. Do not run until the selected core ref supplies a validated template. |
+
+The deployment templates change Azure resources, Terraform state, Key Vault
+content, SAP library content, or host configuration. They do not publish a
+general plan artifact through these wrappers. Pipeline `01` does not pass its
+`test` parameter to deployment scripts. Pipelines `02` and `03` provide
+plan-only runs through `TEST_ONLY`. Use run logs, Terraform output, Azure
+resources, state, and service checks as validation evidence.
+
+## Standalone configuration and update pipelines
+
+| Pipeline | Key parameters | Behavior |
+| --- | --- | --- |
+| `22-sample-deployer-configuration.yml` | Control-plane and workload names, region, optional services, deployer count, identity | Creates missing deployer and library examples, commits them, rewrites selected wrapper defaults, and pushes each change. It does not generate complete workload-zone or SAP-system configuration. |
+| `20-update-repositories.yml` | Core source URL, sample source URL, branch, tag, `force` | Pulls GitHub content into the Azure Repos core and sample repositories. `force: true` force-pushes. |
+| `21-update-pipelines.yml` | Bootstrap source URL, branch, `force` | Copies an enumerated set of wrapper files from source `main`, commits, and pushes. It omits `_v2` and pipeline `07`. `force: true` force-pushes. |
+
+## Removal wrappers
+
+| Wrapper | Core template | Destructive behavior |
+| --- | --- | --- |
+| `10-remover-terraform.yml` | `deploy/pipelines/10-remover-terraform.yaml` | Runs Terraform-based SAP-system and workload-zone removal according to `cleanup_sap` and `cleanup_zone`. The wrapper defaults to SAP-system cleanup enabled and workload-zone cleanup disabled. |
+| `11-remover-arm-fallback.yml` | `deploy/pipelines/11-remover-arm-fallback.yaml` | Deletes selected resource groups through Azure Resource Manager and removes corresponding `WORKSPACES` deployment artifacts. All three cleanup scopes default to enabled in the wrapper. |
+| `12-remove-control-plane.yml` | `deploy/pipelines/12-remove-control-plane.yaml` | Removes the control plane in a deployer-agent stage and a finalization stage. It loads the control-plane variable group and uses `AZURE_CONNECTION_NAME`. |
+
+Use removal in reverse dependency order. Prefer Terraform removal. Treat the ARM
+pipeline as a last-resort fallback, not a normal retry.
+
+## Variable-group dependencies
+
+- Infrastructure templates load `SDAF-General`.
+- Control-plane templates load `SDAF-<control-plane>`.
+- Workload-zone, SAP-system, software, installation, and workload removal
+  templates load `SDAF-<workload-environment>` as applicable.
+- `SDAF-General` supplies shared values including the configuration path, tool
+  versions, and SAP credentials.
+- Environment groups supply Azure identity, subscription, connection, agent,
+  state, and Key Vault values.
+
+See [Troubleshoot Azure DevOps deployments](troubleshooting.md) when a
+dependency cannot be resolved.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,112 @@
+# Troubleshoot Azure DevOps deployments
+
+Use the first failing stage and task as the diagnostic boundary. Preserve the
+run URL, configuration commit, selected parameters, agent name, and relevant
+Azure correlation IDs.
+
+## PAT or Azure DevOps authorization fails
+
+1. Confirm `AZURE_DEVOPS_EXT_PAT` is present only in the current secure process
+   environment, or provide it at the bootstrap prompt.
+2. Verify the PAT is active and has the project, repository, pipeline, variable
+   group, service-connection, and agent-pool permissions required by the
+   selected bootstrap action.
+3. Verify the project build service can read repository resources and contribute
+   to the configuration repository.
+4. Retry only the failed bootstrap or repository operation.
+
+## A variable group is missing
+
+1. Identify the group loaded by the core variable template:
+   `SDAF-General`, `SDAF-<control-plane>`, or
+   `SDAF-<workload-environment>`.
+2. Verify the group exists and is authorized for the pipeline.
+3. Verify required values such as `Deployment_Configuration_Path`,
+   `AZURE_CONNECTION_NAME`, subscription, tenant, `POOL` or `AGENT`, and tool
+   versions.
+4. Verify secret values are marked secret and are not empty.
+
+## A service connection fails
+
+1. Compare `AZURE_CONNECTION_NAME` with the exact service-connection name.
+2. Verify the connection targets the intended tenant and subscription.
+3. Verify its service principal or federated identity exists and has the
+   approved Azure roles.
+4. Verify the connection is authorized for the failing pipeline.
+
+## No agent can run the job
+
+1. Inspect the resolved `POOL`, `AGENT`, or core `this_agent` value.
+2. Verify the pool exists, contains an online compatible agent, and is
+   authorized for the pipeline.
+3. Verify network access from that agent to Azure, Azure Repos, Key Vault,
+   storage, and SAP endpoints.
+4. Verify the Post Build Cleanup extension is installed.
+
+## Repository checkout or template resolution fails
+
+1. Verify `pipelines/resources.yml` or
+   `pipelines/resources_including_samples.yml` names repositories that exist in
+   the Azure DevOps project.
+2. Verify the selected ref exists and the build service can read it.
+3. Verify the wrapper's `extends` path exists in that core ref.
+4. For software download, verify `resources_including_samples.yml` resolves both
+   `sap-automation` and `sap-samples`.
+5. Do not run `07-sap-cal-installation.yml` when its referenced core template is
+   absent.
+
+## Configuration is not found
+
+1. Verify `Deployment_Configuration_Path` points to `WORKSPACES`.
+2. Verify the file is in `DEPLOYER`, `LIBRARY`, `LANDSCAPE`, or `SYSTEM` as
+   appropriate.
+3. Verify the folder and filename match the exact pipeline parameter.
+4. Verify the queued branch contains the approved configuration commit.
+
+## Terraform state or lock fails
+
+1. Stop concurrent pipelines for the same state.
+2. Verify the state storage account, container, key, subscription, and identity.
+3. Confirm whether another active operation owns the lock.
+4. Preserve state before any recovery action. Do not delete state to make a
+   retry proceed.
+
+## Quota, network, or DNS validation fails
+
+1. Identify the Azure region, VM family, address space, route, or DNS name in
+   the first error.
+2. Compare it with the approved configuration and current subscription quota.
+3. Correct the source configuration or approved Azure prerequisite.
+4. Revalidate corrected workload-zone or SAP-system configuration with pipeline
+   `02` or `03` and `test: true` before applying.
+
+## Software download fails
+
+1. Verify the selected BOM exists in the samples repository ref.
+2. Verify `S-Username` and secret `S-Password` in `SDAF-General`.
+3. Verify the agent can reach SAP and the SAP library storage.
+4. Set `re_download: true` only when a deliberate fresh acquisition is required.
+
+## Installation partially completes
+
+1. Record the first failed Ansible play and host.
+2. Correct the host, inventory, media, credential, or playbook input.
+3. Disable completed installation booleans.
+4. Rerun only the required stages and validate their services.
+
+## Removal fails
+
+1. Confirm child resources are being removed before parent resources.
+2. Preserve configuration and state.
+3. Retry Terraform removal after correcting the first failure.
+4. Use the ARM fallback only after reviewing every cleanup boolean and accepting
+   resource-group deletion and `WORKSPACES` artifact removal.
+
+## Ownership
+
+Open issues for wrapper YAML, `WORKSPACES`, or Azure DevOps repository wiring in
+[`Azure/sap-automation-bootstrap`](https://github.com/Azure/sap-automation-bootstrap).
+Open issues for core templates, deployment scripts, Terraform, or Ansible in
+[`Azure/sap-automation`](https://github.com/Azure/sap-automation). Report
+security vulnerabilities through [SECURITY.md](../SECURITY.md), not a public
+issue.


### PR DESCRIPTION
## Summary

- add a complete Azure DevOps setup and deployment journey
- include executable project and workload-zone artifact scripts aligned with Microsoft Learn and current SDAF utilities
- document pipeline behavior, ownership boundaries, operations, and troubleshooting
- preserve `SUPPORT.md` unchanged

## Validation

- verified relative links and anchors
- verified pipeline and repository-resource paths
- parsed embedded PowerShell scripts
- reviewed documentation against current wrapper and core sources
- ran `git diff --check`